### PR TITLE
Update "example" to "varlamorethieving"

### DIFF
--- a/.run/VarlamoreTheiving.run.xml
+++ b/.run/VarlamoreTheiving.run.xml
@@ -2,8 +2,8 @@
   <configuration default="false" name="VarlamoreTheiving" type="Application" factoryName="Application">
     <option name="ALTERNATIVE_JRE_PATH" value="corretto-11" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="MAIN_CLASS_NAME" value="com.example.VarlamoreThieving" />
-    <module name="example.test" />
+    <option name="MAIN_CLASS_NAME" value="com.varlamorethieving.VarlamoreThieving" />
+    <module name="varlamorethieving.test" />
     <selectedOptions>
       <option name="environmentVariables" visible="false" />
     </selectedOptions>

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
-group = 'com.example'
+group = 'com.varlamorethieving'
 version = '1.0-SNAPSHOT'
 
 tasks.withType(JavaCompile) {

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,4 +2,4 @@ displayName=Varlamore Thieving
 author=Skimby
 description=A plugin to assist with house thieving and wealthy citizens.
 tags=thieving,varlamore,house,keys
-plugins=com.example.VarlamoreThievingPlugin
+plugins=com.varlamorethieving.VarlamoreThievingPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'varlamorethieving'

--- a/src/main/java/com/varlamorethieving/VarlamoreThievingConfig.java
+++ b/src/main/java/com/varlamorethieving/VarlamoreThievingConfig.java
@@ -1,10 +1,10 @@
-package com.example;
+package com.varlamorethieving;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("example")
+@ConfigGroup("varlamorethieving")
 public interface VarlamoreThievingConfig extends Config
 {
 	@ConfigItem(

--- a/src/main/java/com/varlamorethieving/VarlamoreThievingPlugin.java
+++ b/src/main/java/com/varlamorethieving/VarlamoreThievingPlugin.java
@@ -1,24 +1,25 @@
 package com.varlamorethieving;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
 import com.google.inject.Provides;
 import com.varlamorethieving.overlay.HouseOverlay;
 import com.varlamorethieving.overlay.WealthyCitizenOverlay;
 
-import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
-
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.client.config.ConfigManager;
 import net.runelite.client.Notifier;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
-
-import java.awt.*;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @PluginDescriptor(

--- a/src/main/java/com/varlamorethieving/VarlamoreThievingPlugin.java
+++ b/src/main/java/com/varlamorethieving/VarlamoreThievingPlugin.java
@@ -1,7 +1,8 @@
-package com.example;
-import com.example.overlay.HouseOverlay;
-import com.example.overlay.WealthyCitizenOverlay;
+package com.varlamorethieving;
 import com.google.inject.Provides;
+import com.varlamorethieving.overlay.HouseOverlay;
+import com.varlamorethieving.overlay.WealthyCitizenOverlay;
+
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;

--- a/src/main/java/com/varlamorethieving/overlay/HouseOverlay.java
+++ b/src/main/java/com/varlamorethieving/overlay/HouseOverlay.java
@@ -1,4 +1,4 @@
-package com.example.overlay;
+package com.varlamorethieving.overlay;
 
 import lombok.Setter;
 import net.runelite.api.*;
@@ -126,4 +126,3 @@ public class HouseOverlay extends Overlay {
         }
     }
 }
-

--- a/src/main/java/com/varlamorethieving/overlay/HouseOverlay.java
+++ b/src/main/java/com/varlamorethieving/overlay/HouseOverlay.java
@@ -1,14 +1,26 @@
 package com.varlamorethieving.overlay;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+
+import javax.inject.Inject;
+
 import lombok.Setter;
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.Constants;
+import net.runelite.api.ObjectComposition;
+import net.runelite.api.Perspective;
 import net.runelite.api.Point;
+import net.runelite.api.Tile;
+import net.runelite.api.WallObject;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-
-import javax.inject.Inject;
-import java.awt.*;
 
 public class HouseOverlay extends Overlay {
     private static final int DOOR_BEFORE_ID = 51999;

--- a/src/main/java/com/varlamorethieving/overlay/WealthyCitizenOverlay.java
+++ b/src/main/java/com/varlamorethieving/overlay/WealthyCitizenOverlay.java
@@ -1,4 +1,21 @@
-package com.example.overlay;
+package com.varlamorethieving.overlay;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
 
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
@@ -12,14 +29,6 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
-
-import java.time.*;
-import java.util.*;
-
-
-import javax.inject.Inject;
-import java.awt.*;
-import java.util.List;
 
 public class WealthyCitizenOverlay extends Overlay {
     private final Client client;
@@ -148,8 +157,3 @@ public class WealthyCitizenOverlay extends Overlay {
     }
 
     }
-
-
-
-
-

--- a/src/test/java/com/varlamorethieving/VarlamoreThieving.java
+++ b/src/test/java/com/varlamorethieving/VarlamoreThieving.java
@@ -1,7 +1,5 @@
 package com.varlamorethieving;
 
-import com.varlamorethieving.VarlamoreThievingPlugin;
-
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 

--- a/src/test/java/com/varlamorethieving/VarlamoreThieving.java
+++ b/src/test/java/com/varlamorethieving/VarlamoreThieving.java
@@ -1,4 +1,6 @@
-package com.example;
+package com.varlamorethieving;
+
+import com.varlamorethieving.VarlamoreThievingPlugin;
 
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;


### PR DESCRIPTION
a friend of mine wanted a varlamore thieving plugin and I saw that yours was in review, so I figured I could help out in getting it merged
you got feedback on the PR that the having `"example"` for `@ConfigGroup` wasn't going to cut it, so I just changed all references from `example` to `varlamorethieving`, including package/folder names and whatever else.

I'm using VSCode rather than IntelliJ so I can't validate the `.run` configurations, but I did run the plugin and go run over to Varlamore to make sure it still works as intended.

There's some auto-import shenanigans where my editor had some opinions, but they don't change anything about the actual plugin behavior.

Hope this helps get it merged faster @zenolook123 😄 